### PR TITLE
Issue #63: Add an option to return the MCP results as resource items

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
- ELEVENLABS_API_KEY=PUT_YOUR_KEY_HERE
- ELEVENLABS_MCP_BASE_PATH=~/Desktop # optional base path for output files
- ELEVENLABS_API_RESIDENCY="us" # optional data residency location
+ELEVENLABS_API_KEY=PUT_YOUR_KEY_HERE
+ELEVENLABS_MCP_BASE_PATH=~/Desktop # optional base path for output files
+ELEVENLABS_API_RESIDENCY="us" # optional data residency location
+ELEVENLABS_MCP_OUTPUT_MODE=files # output mode: files, resources, or both

--- a/README.md
+++ b/README.md
@@ -63,9 +63,51 @@ Try asking Claude:
 
 ## Optional features
 
-### Base output file path
+### File Output Configuration
 
-You can add the `ELEVENLABS_MCP_BASE_PATH` environment variable to the `claude_desktop_config.json` to specify the base path MCP server should look for and output files specified with relative paths.
+You can configure how the MCP server handles file outputs using these environment variables in your `claude_desktop_config.json`:
+
+- **`ELEVENLABS_MCP_BASE_PATH`**: Specify the base path for file operations with relative paths (default: `~/Desktop`)
+- **`ELEVENLABS_MCP_OUTPUT_MODE`**: Control how generated files are returned (default: `files`)
+
+#### Output Modes
+
+The `ELEVENLABS_MCP_OUTPUT_MODE` environment variable supports three modes:
+
+1. **`files`** (default): Save files to disk and return file paths
+   ```json
+   "env": {
+     "ELEVENLABS_API_KEY": "your-api-key",
+     "ELEVENLABS_MCP_OUTPUT_MODE": "files"
+   }
+   ```
+
+2. **`resources`**: Return files as MCP resources; binary data is base64-encoded, text is returned as UTF-8 text
+   ```json
+   "env": {
+     "ELEVENLABS_API_KEY": "your-api-key",
+     "ELEVENLABS_MCP_OUTPUT_MODE": "resources"
+   }
+   ```
+
+3. **`both`**: Save files to disk AND return as MCP resources
+   ```json
+   "env": {
+     "ELEVENLABS_API_KEY": "your-api-key",
+     "ELEVENLABS_MCP_OUTPUT_MODE": "both"
+   }
+   ```
+
+**Resource Mode Benefits:**
+- Files are returned directly in the MCP response as base64-encoded data
+- No disk I/O required - useful for containerized or serverless environments
+- MCP clients can access file content immediately without file system access
+- In `both` mode, resources can be fetched later using the `elevenlabs://filename` URI pattern
+
+**Use Cases:**
+- `files`: Traditional file-based workflows, local development
+- `resources`: Cloud environments, MCP clients without file system access
+- `both`: Maximum flexibility, caching, and resource sharing scenarios
 
 ### Data residency keys
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable output modes for generated assets: files, resources, or both.
  - Added a resource endpoint to access generated assets directly (streamed or returned without disk persistence).
  - New environment variable ELEVENLABS_MCP_OUTPUT_MODE and support for base path via ELEVENLABS_MCP_BASE_PATH.

- **Documentation**
  - README updated with "File Output Configuration", detailed "Output Modes", examples, benefits, and use cases.
  - Clarified data residency guidance.

- **Chores**
  - Updated .env example formatting; added ELEVENLABS_MCP_OUTPUT_MODE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->